### PR TITLE
Update header brand and navigation

### DIFF
--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -4,11 +4,8 @@ export default function Navbar() {
     <header className="sticky top-0 z-50 bg-white/80 backdrop-blur supports-[backdrop-filter]:bg-white/60">
       <div className="container mx-auto flex items-center justify-between px-4 py-3 max-w-6xl">
         <Link href="/" className="text-lg font-bold">
-          SuperfastSAT
+          satinsiders
         </Link>
-        <nav className="hidden md:flex items-center gap-6 text-sm font-medium">
-          <Link href="/blog" className="hover:text-accent">Blog</Link>
-        </nav>
         <Link
           href="#cta"
           className="rounded-lg bg-accent px-4 py-2 text-white text-sm font-semibold shadow hover:opacity-90"


### PR DESCRIPTION
## Summary
- rename header brand to `satinsiders`
- remove the blog link from the header

## Testing
- `npx eslint .` *(fails: parsing errors without config)*
- `npm run build` *(fails: module not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855367f424083309d9e61e90de87652