### PR TITLE
Redirect CTAs to signup form

### DIFF
--- a/components/Footer.js
+++ b/components/Footer.js
@@ -9,7 +9,7 @@ export default function Footer() {
           now.
         </p>
         <a
-          href="https://forms.gle/your_google_form" // replace
+          href="https://forms.gle/h78DBjJcRDVpdB1a7"
           className="inline-block rounded-lg bg-accent px-8 py-4 text-white font-semibold shadow hover:opacity-90"
         >
           Get Started

--- a/components/Hero.js
+++ b/components/Hero.js
@@ -26,7 +26,7 @@ export default function Hero() {
           </p>
           <div className="flex flex-wrap items-center gap-4">
             <Link
-              href="#cta"
+              href="https://forms.gle/h78DBjJcRDVpdB1a7"
               className="rounded-lg bg-accent px-6 py-3 text-white font-semibold shadow hover:opacity-90"
             >
               Start free trial

--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -7,7 +7,7 @@ export default function Navbar() {
           satinsiders
         </Link>
         <Link
-          href="#cta"
+          href="https://forms.gle/h78DBjJcRDVpdB1a7"
           className="rounded-lg bg-accent px-4 py-2 text-white text-sm font-semibold shadow hover:opacity-90"
         >
           Get Started

--- a/components/PriceTeaser.js
+++ b/components/PriceTeaser.js
@@ -13,7 +13,7 @@ export default function PriceTeaser() {
           </span>
         </p>
         <Link
-          href="#pricing"
+          href="https://forms.gle/h78DBjJcRDVpdB1a7"
           className="inline-block rounded-lg bg-white/10 px-8 py-4 font-semibold hover:bg-white/20"
         >
           See plan details

--- a/components/Pricing.js
+++ b/components/Pricing.js
@@ -22,7 +22,7 @@ const plans = [
       'Daily high-frequency vocab training',
       'Cancel any time',
     ],
-    cta: { label: 'Start Free Trial', href: '/checkout?plan=daily-care' },
+    cta: { label: 'Start Free Trial', href: 'https://forms.gle/h78DBjJcRDVpdB1a7' },
   },
   {
     id: 'tutoring',
@@ -37,7 +37,7 @@ const plans = [
       'Flexible scheduling',
       'Purchasable by the hour',
     ],
-    cta: { label: 'Book a Session', href: '/checkout?plan=tutoring' },
+    cta: { label: 'Book a Session', href: 'https://forms.gle/h78DBjJcRDVpdB1a7' },
   },
 ];
 


### PR DESCRIPTION
## Summary
- update every CTA link to point to the Google form

## Testing
- `npm install`
- `npm run lint` *(fails: Next.js wants interactive setup)*
- `npm run build` *(fails: missing assets and module errors)*

------
https://chatgpt.com/codex/tasks/task_e_685538994f848330b0353a05b393af39