### PR TITLE
Add Google Tag Manager script

### DIFF
--- a/pages/_document.js
+++ b/pages/_document.js
@@ -3,6 +3,15 @@ export default function Document() {
   return (
     <Html lang="en">
       <Head>
+        {/* Google Tag Manager */}
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `(
+              function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);}
+            )(window,document,'script','dataLayer','GTM-KNZTP9TB');`,
+          }}
+        />
+        {/* End Google Tag Manager */}
         <link
           href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap"
           rel="stylesheet"
@@ -10,6 +19,16 @@ export default function Document() {
         <meta name="viewport" content="width=device-width, initial-scale=1" />
       </Head>
       <body className="font-body text-gray-800">
+        {/* Google Tag Manager (noscript) */}
+        <noscript>
+          <iframe
+            src="https://www.googletagmanager.com/ns.html?id=GTM-KNZTP9TB"
+            height="0"
+            width="0"
+            style={{ display: 'none', visibility: 'hidden' }}
+          ></iframe>
+        </noscript>
+        {/* End Google Tag Manager (noscript) */}
         <Main />
         <NextScript />
       </body>


### PR DESCRIPTION
## Summary
- embed Google Tag Manager script in the HTML head
- include noscript variant right after `<body>`

## Testing
- `npm test` *(fails: Missing script)*
- `npx next lint` *(fails to install `next`)*

------
https://chatgpt.com/codex/tasks/task_e_685656c420348330bbd070ab5aed8c7e