### PR TITLE
Link CTA buttons to free trial page

### DIFF
--- a/components/Footer.js
+++ b/components/Footer.js
@@ -9,7 +9,7 @@ export default function Footer() {
           now.
         </p>
         <a
-          href="#lead"
+          href="/free-trial"
           className="inline-block rounded-lg bg-accent px-8 py-4 text-white font-semibold shadow hover:opacity-90"
         >
           Get Started

--- a/components/Hero.js
+++ b/components/Hero.js
@@ -26,7 +26,7 @@ export default function Hero() {
           </p>
           <div className="flex flex-wrap items-center gap-4">
             <Link
-              href="#lead"
+              href="/free-trial"
               className="rounded-lg bg-accent px-6 py-3 text-white font-semibold shadow hover:opacity-90"
             >
               Start free trial

--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -11,7 +11,7 @@ export default function Navbar() {
           satinsiders
         </Link>
         <Link
-          href="#lead"
+          href="/free-trial"
           className="hidden md:inline-block rounded-lg bg-accent px-4 py-2 text-white text-sm font-semibold shadow hover:opacity-90"
         >
           Get Started
@@ -29,7 +29,7 @@ export default function Navbar() {
             Blog
           </Link>
           <Link
-            href="#lead"
+            href="/free-trial"
             className="mt-2 block w-full rounded-lg bg-accent px-4 py-2 text-center text-sm font-semibold text-white shadow hover:opacity-90"
             onClick={() => setOpen(false)}
           >

--- a/components/Pricing.js
+++ b/components/Pricing.js
@@ -22,7 +22,7 @@ const plans = [
       'Daily high-frequency vocab training',
       'Cancel any time',
     ],
-    cta: { label: 'Start Free Trial', href: '#lead' },
+    cta: { label: 'Start Free Trial', href: '/free-trial' },
   },
   {
     id: 'tutoring',


### PR DESCRIPTION
## Summary
- link hero call-to-action to `/free-trial`
- update pricing CTA link
- connect navbar and footer buttons to free-trial page

## Testing
- `npm run lint` *(fails: prompts to configure ESLint)*

------
https://chatgpt.com/codex/tasks/task_e_6859210fe27c83308c565a39f4fc0877