### PR TITLE
Add sticky promo footer

### DIFF
--- a/components/StickyFooter.js
+++ b/components/StickyFooter.js
@@ -1,0 +1,9 @@
+import React from "react";
+
+export default function StickyFooter() {
+  return (
+    <div className="fixed bottom-0 left-0 w-full bg-accent text-white text-center py-3 z-50">
+      🎯 100% Free August SAT Prep – Only 100 Spots!
+    </div>
+  );
+}

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,4 +1,10 @@
 import "../styles/globals.css";
+import StickyFooter from "../components/StickyFooter";
+
 export default function MyApp({ Component, pageProps }) {
-  return <Component {...pageProps} />;
-}
+  return (
+    <>
+      <Component {...pageProps} />
+      <StickyFooter />
+    </>
+  );}


### PR DESCRIPTION
## Summary
- add StickyFooter component to show promo banner
- mount StickyFooter from `_app.js`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686dfcd2ad988330b7d784b23d1eea02