### PR TITLE
Fix Get Started CTA linking on policy pages

### DIFF
--- a/components/Footer.js
+++ b/components/Footer.js
@@ -9,7 +9,7 @@ export default function Footer() {
           now.
         </p>
         <a
-          href="#lead"
+          href="/#lead"
           className="inline-block rounded-lg bg-accent px-8 py-4 text-white font-semibold shadow hover:opacity-90"
         >
           Get Started

--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -11,7 +11,7 @@ export default function Navbar() {
           satinsiders
         </Link>
         <Link
-          href="#lead"
+          href="/#lead"
           className="hidden md:inline-block rounded-lg bg-accent px-4 py-2 text-white text-sm font-semibold shadow hover:opacity-90"
         >
           Get Started
@@ -29,7 +29,7 @@ export default function Navbar() {
             Blog
           </Link>
           <Link
-            href="#lead"
+            href="/#lead"
             className="mt-2 block w-full rounded-lg bg-accent px-4 py-2 text-center text-sm font-semibold text-white shadow hover:opacity-90"
             onClick={() => setOpen(false)}
           >


### PR DESCRIPTION
## Summary
- Ensure navbar Get Started button links to main page lead section
- Adjust footer Get Started CTA to target landing page lead section

## Testing
- `npm test`
- `npm run lint` *(fails: requires ESLint configuration interaction)*

------
https://chatgpt.com/codex/tasks/task_e_689c3477583c83309999d30f0639bf0e