### PR TITLE
Rebrand satinsiders references to Daily Care

### DIFF
--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -7,8 +7,13 @@ export default function Navbar() {
   return (
     <header className="sticky top-0 z-50 bg-white/80 backdrop-blur supports-[backdrop-filter]:bg-white/60">
       <div className="container mx-auto flex items-center justify-between px-4 py-3 max-w-6xl">
-        <Link href="/" className="text-lg font-bold">
-          satinsiders
+        <Link href="/" className="flex items-center gap-2 text-lg font-bold">
+          <img
+            src="/daily-care-icon.ico"
+            alt="Daily Care logo"
+            className="h-8 w-8"
+          />
+          Daily Care
         </Link>
         <Link
           href="/#lead"

--- a/pages/privacy-policy.js
+++ b/pages/privacy-policy.js
@@ -247,7 +247,7 @@ export default function PrivacyPolicy() {
             <br />
             Los Angeles, CA 90025
             <br />
-            Email: jason@satinsiders.com
+            Email: jason@dailycare.com
           </p>
         </section>
       </main>

--- a/pages/subscribe.js
+++ b/pages/subscribe.js
@@ -126,7 +126,7 @@ export default function Subscribe() {
                 Contact via WhatsApp
               </a>
               <a
-                href="mailto:satinsiders@gmail.com"
+                href="mailto:dailycare@gmail.com"
                 className="rounded-lg border border-accent px-6 py-3 font-semibold text-accent hover:bg-accent/10"
               >
                 Email Us

--- a/pages/terms-of-service.js
+++ b/pages/terms-of-service.js
@@ -353,7 +353,7 @@ export default function TermsOfService() {
             <br />
             Los Angeles, CA 90025
             <br />
-            Email: jason@satinsiders.com
+            Email: jason@dailycare.com
           </p>
         </section>
       </main>


### PR DESCRIPTION
## Summary
- Update navbar with Daily Care branding and logo
- Replace satinsiders contact emails across pages with Daily Care

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689d381c81d083308d085fc8a8a4aff3