### PR TITLE
Move social proof earlier and enhance hero

### DIFF
--- a/components/Hero.js
+++ b/components/Hero.js
@@ -38,6 +38,13 @@ export default function Hero() {
               About
             </Link>
           </div>
+          <div className="flex flex-wrap gap-3 text-sm font-medium text-gray-700">
+            <span className="rounded-full bg-light px-4 py-1">+160 pts avg in 4 wks</span>
+            <span className="rounded-full bg-light px-4 py-1">65% hit 1400+</span>
+          </div>
+          <p className="text-sm text-gray-500 italic">
+            “Daily Care turned studying into bite-size missions.” — Sarah K.
+          </p>
         </div>
       </div>
     </Section>

--- a/pages/index.js
+++ b/pages/index.js
@@ -27,8 +27,9 @@ export default function Home() {
       <main>
         <Hero />
         <PainStatement />
-        <Trusted />
         <Stats />
+        <Testimonials />
+        <Trusted />
         <PriceTeaser />
         <BuiltAround />
         <HowItWorks />
@@ -37,7 +38,6 @@ export default function Home() {
         <LeadForm />
         <Curriculum />
         <ComparisonTable />
-        <Testimonials />
         <FAQ />
       </main>
       <Footer />

--- a/pages/index.js
+++ b/pages/index.js
@@ -28,14 +28,14 @@ export default function Home() {
         <Hero />
         <PainStatement />
         <Stats />
+        <PriceTeaser />
         <Testimonials />
         <Trusted />
-        <PriceTeaser />
         <BuiltAround />
-        <HowItWorks />
-        <Features />
         <Pricing />
         <LeadForm />
+        <HowItWorks />
+        <Features />
         <Curriculum />
         <ComparisonTable />
         <FAQ />


### PR DESCRIPTION
## Summary
- Move Stats and Testimonials sections near the top to show social proof sooner
- Add stat badges and a quick testimonial quote within the hero section

## Testing
- `npm test`
- `npm run lint` *(fails: requires interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_689d384935e88330963b845e7c883e1a