### PR TITLE
Introduce minimal-context pipeline runner

### DIFF
--- a/tests/pipeline.test.js
+++ b/tests/pipeline.test.js
@@ -1,0 +1,25 @@
+const { runPipeline } = require('../utils/pipeline');
+
+describe('runPipeline', () => {
+  test('passes only required data to each step', () => {
+    const step1 = {
+      inputs: ['text'],
+      run: jest.fn(({ text }) => ({ summary: text.slice(0, 5) })),
+    };
+
+    const step2 = {
+      inputs: ['summary'],
+      run: jest.fn(({ summary }) => ({ final: summary.toUpperCase() })),
+    };
+
+    const result = runPipeline([step1, step2], {
+      text: 'hello world',
+      irrelevant: 'should not be forwarded',
+    });
+
+    expect(step1.run.mock.calls[0][0]).toEqual({ text: 'hello world' });
+    expect(step2.run.mock.calls[0][0]).toEqual({ summary: 'hello' });
+    expect(result.final).toBe('HELLO');
+    expect(result.irrelevant).toBe('should not be forwarded');
+  });
+});

--- a/utils/pipeline.js
+++ b/utils/pipeline.js
@@ -1,0 +1,21 @@
+function runPipeline(steps, initialContext = {}) {
+  const context = { ...initialContext };
+
+  for (const step of steps) {
+    const stepInput = {};
+    if (Array.isArray(step.inputs)) {
+      for (const key of step.inputs) {
+        if (Object.prototype.hasOwnProperty.call(context, key)) {
+          stepInput[key] = context[key];
+        }
+      }
+    }
+
+    const output = step.run(stepInput);
+    Object.assign(context, output);
+  }
+
+  return context;
+}
+
+module.exports = { runPipeline };


### PR DESCRIPTION
## Summary
- add pipeline runner that only passes specified data to each step
- cover pipeline runner with unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d457808b083309a85159cdad22330