### PR TITLE
Adjust PainStatement spacing and line height

### DIFF
--- a/components/PainStatement.js
+++ b/components/PainStatement.js
@@ -2,14 +2,14 @@ import Section from "./Section";
 
 export default function PainStatement() {
   return (
-    <Section className="bg-accent text-white text-center !py-20 px-4">
+    <Section className="bg-accent text-white text-center py-12 md:py-20 px-4">
       <div className="flex flex-col items-center gap-y-12">
-        <p className="text-2xl md:text-3xl font-medium text-white/90 mb-8">
+        <p className="text-2xl md:text-3xl font-medium text-white/90">
           Still stuck below 1400?
         </p>
 
         {/* bumped to Tailwind’s loosest preset */}
-        <p className="text-4xl md:text-5xl font-bold leading-[2.25] tracking-wide">
+        <p className="text-4xl md:text-5xl font-bold leading-tight md:leading-[2.25] tracking-wide">
           Generic drills don’t show you why you miss questions—or how to fix them.
         </p>
       </div>


### PR DESCRIPTION
## Summary
- Tweak PainStatement section padding for better mobile spacing
- Use compact line height on mobile and preserve looser desktop style

## Testing
- `npm test`
- `npm run lint` *(fails: requires ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689d9cd8f840833085e20178d8b00b00